### PR TITLE
improved map rendering

### DIFF
--- a/DisplayManager.cpp
+++ b/DisplayManager.cpp
@@ -248,7 +248,7 @@ void DisplayManager::refresh(void) {
     Entity *e;
 
     // Map rendering
-		renderMap->mapDrawer(renderer, txMan);
+		renderMap->mapDrawer(renderer);
 
     for (int i = 0; i < entities.size(); ++i) {
         e = entities[i];

--- a/main.cpp
+++ b/main.cpp
@@ -31,6 +31,8 @@ int main( int argc, char **argv ) {
 	SDL_Renderer *renderer = SDL_CreateRenderer(window, -1, 0);
 	TextureManager *txMan = new TextureManager(renderer);
 	MapManager *map = new MapManager();
+	map->texturePreloader(txMan);
+	map->levelLoader(1);
 	DisplayManager dispMan(renderer, txMan, map);
 
 	Humanoid *player = dispMan.spawnHumanoid(ET_PLAYER);

--- a/map.h
+++ b/map.h
@@ -22,19 +22,22 @@ class mapTile {
 		//Constructor
 		mapTile();
 		//Argumented Constructor
-		mapTile(int x, int y, tileID id);
+		mapTile(int x, int y, tileID id, SDL_Texture * texture );
 
 		//Set tile data
 		void setTileData(int x, int y, int h, int w, tileID id);
 		//Returns tile ID
 		tileID getType();
 		//Returns SDL_Rect stored
-		SDL_Rect getTile();
+		SDL_Rect* getTile();
+		//Returns SDL_Texture stored
+		SDL_Texture* getTileTexture();
 
 	private:
 
 		tileID tID;
 		SDL_Rect tileData;
+		SDL_Texture* tileTexture;
 
 };
 
@@ -42,13 +45,15 @@ class MapManager {
 	public:	
 		MapManager();
 		~MapManager();
-
-		void mapDrawer(SDL_Renderer * renderer, TextureManager * txMan); 
+		
+		void texturePreloader(TextureManager * txMan); 
+		void mapDrawer(SDL_Renderer * renderer); 
 		void levelLoader(int level);
+		SDL_Texture* textureUnloader(int tile_type);
 
 		tileID textureToTile(int tile_type);
 		TextureID tileToTexture(int texture_type);
 	private:
-		SDL_Surface *mapSurface;
+		std::vector<SDL_Texture*> mapTextures;
 		std::vector<std::vector<mapTile*> > gameMap;
 };


### PR DESCRIPTION
Textures are now preloaded into each tile so that when refreshing the display there is no longer a switch statement or any loading of textures, it is all sent to the renderer when the map is built.